### PR TITLE
chore(deps): update to reference renamed sn_transfers crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1631,22 +1631,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "safe-transfers"
-version = "0.1.0"
-source = "git+https://github.com/maidsafe/safe-transfers.git#5960b53ac23278552b9c30911021233c770895f3"
-dependencies = [
- "bincode",
- "crdts",
- "itertools",
- "log",
- "rand",
- "safe-nd",
- "serde",
- "threshold_crypto",
- "xor_name",
-]
-
-[[package]]
 name = "safe_core"
 version = "0.42.1"
 dependencies = [
@@ -1673,12 +1657,12 @@ dependencies = [
  "rand",
  "regex",
  "safe-nd",
- "safe-transfers",
  "self_encryption",
  "serde",
  "serde-value",
  "serde_json",
  "sha3",
+ "sn_transfers",
  "tempfile",
  "threshold_crypto",
  "tiny-keccak 1.5.0",
@@ -1820,6 +1804,23 @@ name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
+
+[[package]]
+name = "sn_transfers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8138235120e51c208f6cb47319f13b5db6ce15f6fe380be00cf9a7fdffef9d58"
+dependencies = [
+ "bincode",
+ "crdts",
+ "itertools",
+ "log",
+ "rand",
+ "safe-nd",
+ "serde",
+ "threshold_crypto",
+ "xor_name",
+]
 
 [[package]]
 name = "spin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ quic-p2p = { git = "https://github.com/yoga07/quic-p2p.git", branch = "old-async
 rand = "~0.7.3"
 regex = "1.3.1"
 safe-nd = "~0.11.2"
-safe-transfers = "~0.1.0"
+sn_transfers = "~0.2.0"
 self_encryption = "~0.19.0"
 serde = { version = "1.0.111", features = ["derive", "rc"] }
 serde_json = "1.0.53"
@@ -53,10 +53,9 @@ serde_json = "1.0.9"
 tempfile = "3.1.0"
 
 [features]
-simulated-payouts = ["safe-nd/simulated-payouts", "safe-transfers/simulated-payouts"]
+simulated-payouts = ["safe-nd/simulated-payouts", "sn_transfers/simulated-payouts"]
 testing = []
 
 [patch.crates-io]
 safe-nd = { git = "https://github.com/maidsafe/safe-nd.git" }
-safe-transfers = { git = "https://github.com/maidsafe/safe-transfers.git" }
 self_encryption = { git = "https://github.com/joshuef/self_encryption.git", branch = "AllowMutGet" }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -23,7 +23,7 @@ pub mod sequence_apis;
 
 mod blob_storage;
 
-// safe-transfers wrapper
+// sn_transfers wrapper
 pub use self::map_info::MapInfo;
 pub use self::transfer_actor::{ClientTransferValidator, SafeTransferActor};
 

--- a/src/client/transfer_actor/balance_management.rs
+++ b/src/client/transfer_actor/balance_management.rs
@@ -2,7 +2,7 @@ use safe_nd::{
     Cmd, DebitAgreementProof, Event, Money, PublicKey, Query, QueryResponse, TransferCmd,
     TransferQuery,
 };
-use safe_transfers::{ActorEvent, TransferInitiated};
+use sn_transfers::{ActorEvent, TransferInitiated};
 
 use crate::client::Client;
 use crate::errors::CoreError;

--- a/src/client/transfer_actor/mod.rs
+++ b/src/client/transfer_actor/mod.rs
@@ -3,11 +3,11 @@ use safe_nd::{
     TransferCmd, TransferQuery,
 };
 
-use safe_transfers::{ActorEvent, ReplicaValidator, TransferInitiated};
+use sn_transfers::{ActorEvent, ReplicaValidator, TransferInitiated};
 
 use crate::client::{Client, COST_OF_PUT};
 use crate::errors::CoreError;
-pub use safe_transfers::TransferActor as SafeTransferActor;
+pub use sn_transfers::TransferActor as SafeTransferActor;
 
 use log::{debug, info, trace, warn};
 
@@ -65,7 +65,7 @@ impl Client {
     /// Retrieve the history of the acocunt from the network and apply to our local actor
     pub async fn get_history(&mut self) -> Result<(), CoreError> {
         let public_key = *self.full_id.public_key();
-        info!("Getting SafeTransfers history for pk: {:?}", public_key);
+        info!("Getting SnTransfers history for pk: {:?}", public_key);
 
         let msg_contents = Query::Transfer(TransferQuery::GetHistory {
             at: public_key,

--- a/src/client/transfer_actor/write_apis.rs
+++ b/src/client/transfer_actor/write_apis.rs
@@ -1,5 +1,5 @@
 use safe_nd::DebitAgreementProof;
-use safe_transfers::ActorEvent;
+use sn_transfers::ActorEvent;
 
 use crate::client::Client;
 use crate::errors::CoreError;


### PR DESCRIPTION
As safe-vault currently has this branch as it's [safe_core dev dependency](https://github.com/maidsafe/safe-vault/blob/master/Cargo.toml#L59) I need to update it with the new sn_transfers crate rename, to allow vaults to compile.
